### PR TITLE
Add base fee to header table

### DIFF
--- a/db/migrations/00024_add_base_fee.sql
+++ b/db/migrations/00024_add_base_fee.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 ALTER TABLE eth.header_cids
-ADD COLUMN base_fee BIGINT DEFAULT 0;
+ADD COLUMN base_fee BIGINT;
 
 -- +goose Down
 ALTER TABLE eth.header_cids

--- a/db/migrations/00024_add_base_fee.sql
+++ b/db/migrations/00024_add_base_fee.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE eth.header_cids
+ADD COLUMN base_fee BIGINT DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE eth.header_cids
+DROP COLUMN base_fee;


### PR DESCRIPTION
`base_fee` is added in EIP-1559. The code in Ethereum state diff got merged here. https://github.com/vulcanize/go-ethereum/pull/93/commits/3eb4467799eb854b091e2d626bb4fe782be08f98