### PR TITLE
fix 00027 UP and DOWN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,8 @@ docker-build:
 migrate: $(GOOSE) checkdbvars
 	$(GOOSE) -dir db/migrations postgres "$(CONNECT_STRING)" up
 	pg_dump -O -s $(CONNECT_STRING) > db/schema.sql
+
+## Apply all DOWN migrations
+.PHONY: down
+down: $(GOOSE) checkdbvars
+	$(GOOSE) -dir db/migrations postgres "$(CONNECT_STRING)" down

--- a/db/migrations/00027_rename_cid_and_mh_key_in_eth_receipt_cids.sql
+++ b/db/migrations/00027_rename_cid_and_mh_key_in_eth_receipt_cids.sql
@@ -6,17 +6,67 @@ ALTER TABLE eth.receipt_cids
 RENAME COLUMN mh_key TO leaf_mh_key;
 
 ALTER INDEX eth.rct_mh_index
-RENAME TO rct_leaf_cid_index;
+RENAME TO rct_leaf_mh_key_index;
 
 ALTER INDEX eth.rct_cid_index
-RENAME TO rct_leaf_mh_key_index;
+RENAME TO rct_leaf_cid_index;
 
 DROP FUNCTION header_weight;
 DROP FUNCTION canonical_header;
 
 -- +goose Down
-DROP INDEX eth.rct_leaf_cid_index;
-DROP INDEX eth.rct_leaf_mh_key_index;
+-- +goose StatementBegin
+-- returns the number of child headers that reference backwards to the header with the provided hash
+CREATE OR REPLACE FUNCTION header_weight(hash VARCHAR(66)) RETURNS BIGINT
+AS $$
+  WITH RECURSIVE validator AS (
+          SELECT block_hash, parent_hash, block_number
+          FROM eth.header_cids
+          WHERE block_hash = hash
+      UNION
+          SELECT eth.header_cids.block_hash, eth.header_cids.parent_hash, eth.header_cids.block_number
+          FROM eth.header_cids
+          INNER JOIN validator
+            ON eth.header_cids.parent_hash = validator.block_hash
+            AND eth.header_cids.block_number = validator.block_number + 1
+  )
+SELECT COUNT(*) FROM validator;
+$$ LANGUAGE SQL;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- returns the id for the header at the provided height which is heaviest
+CREATE OR REPLACE FUNCTION canonical_header(height BIGINT) RETURNS INT AS
+$BODY$
+DECLARE
+current_weight INT;
+  heaviest_weight INT DEFAULT 0;
+  heaviest_id INT;
+  r eth.header_cids%ROWTYPE;
+BEGIN
+FOR r IN SELECT * FROM eth.header_cids
+         WHERE block_number = height
+             LOOP
+SELECT INTO current_weight * FROM header_weight(r.block_hash);
+IF current_weight > heaviest_weight THEN
+        heaviest_weight := current_weight;
+        heaviest_id := r.id;
+END IF;
+END LOOP;
+RETURN heaviest_id;
+END
+$BODY$
+LANGUAGE 'plpgsql';
+-- +goose StatementEnd
+
+ALTER INDEX eth.rct_leaf_cid_index
+RENAME TO rct_cid_index;
+
+ALTER INDEX eth.rct_leaf_mh_key_index
+RENAME TO rct_mh_index;
+
 ALTER TABLE eth.receipt_cids
-DROP COLUMN leaf_cid,
-DROP COLUMN leaf_mh_key;
+RENAME COLUMN leaf_mh_key TO mh_key;
+
+ALTER TABLE eth.receipt_cids
+RENAME COLUMN leaf_cid TO cid;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.12
--- Dumped by pg_dump version 13.4 (Ubuntu 13.4-1.pgdg20.04+1)
+-- Dumped from database version 14beta3
+-- Dumped by pg_dump version 14beta3
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -24,6 +24,8 @@ CREATE SCHEMA eth;
 
 
 SET default_tablespace = '';
+
+SET default_table_access_method = heap;
 
 --
 -- Name: header_cids; Type: TABLE; Schema: eth; Owner: -
@@ -1038,14 +1040,14 @@ CREATE INDEX rct_contract_index ON eth.receipt_cids USING btree (contract);
 -- Name: rct_leaf_cid_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE INDEX rct_leaf_cid_index ON eth.receipt_cids USING btree (leaf_mh_key);
+CREATE INDEX rct_leaf_cid_index ON eth.receipt_cids USING btree (leaf_cid);
 
 
 --
 -- Name: rct_leaf_mh_key_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE INDEX rct_leaf_mh_key_index ON eth.receipt_cids USING btree (leaf_cid);
+CREATE INDEX rct_leaf_mh_key_index ON eth.receipt_cids USING btree (leaf_mh_key);
 
 
 --
@@ -1206,49 +1208,49 @@ CREATE INDEX tx_src_index ON eth.transaction_cids USING btree (src);
 -- Name: header_cids header_cids_ai; Type: TRIGGER; Schema: eth; Owner: -
 --
 
-CREATE TRIGGER header_cids_ai AFTER INSERT ON eth.header_cids FOR EACH ROW EXECUTE PROCEDURE eth.graphql_subscription('header_cids', 'id');
+CREATE TRIGGER header_cids_ai AFTER INSERT ON eth.header_cids FOR EACH ROW EXECUTE FUNCTION eth.graphql_subscription('header_cids', 'id');
 
 
 --
 -- Name: receipt_cids receipt_cids_ai; Type: TRIGGER; Schema: eth; Owner: -
 --
 
-CREATE TRIGGER receipt_cids_ai AFTER INSERT ON eth.receipt_cids FOR EACH ROW EXECUTE PROCEDURE eth.graphql_subscription('receipt_cids', 'id');
+CREATE TRIGGER receipt_cids_ai AFTER INSERT ON eth.receipt_cids FOR EACH ROW EXECUTE FUNCTION eth.graphql_subscription('receipt_cids', 'id');
 
 
 --
 -- Name: state_accounts state_accounts_ai; Type: TRIGGER; Schema: eth; Owner: -
 --
 
-CREATE TRIGGER state_accounts_ai AFTER INSERT ON eth.state_accounts FOR EACH ROW EXECUTE PROCEDURE eth.graphql_subscription('state_accounts', 'id');
+CREATE TRIGGER state_accounts_ai AFTER INSERT ON eth.state_accounts FOR EACH ROW EXECUTE FUNCTION eth.graphql_subscription('state_accounts', 'id');
 
 
 --
 -- Name: state_cids state_cids_ai; Type: TRIGGER; Schema: eth; Owner: -
 --
 
-CREATE TRIGGER state_cids_ai AFTER INSERT ON eth.state_cids FOR EACH ROW EXECUTE PROCEDURE eth.graphql_subscription('state_cids', 'id');
+CREATE TRIGGER state_cids_ai AFTER INSERT ON eth.state_cids FOR EACH ROW EXECUTE FUNCTION eth.graphql_subscription('state_cids', 'id');
 
 
 --
 -- Name: storage_cids storage_cids_ai; Type: TRIGGER; Schema: eth; Owner: -
 --
 
-CREATE TRIGGER storage_cids_ai AFTER INSERT ON eth.storage_cids FOR EACH ROW EXECUTE PROCEDURE eth.graphql_subscription('storage_cids', 'id');
+CREATE TRIGGER storage_cids_ai AFTER INSERT ON eth.storage_cids FOR EACH ROW EXECUTE FUNCTION eth.graphql_subscription('storage_cids', 'id');
 
 
 --
 -- Name: transaction_cids transaction_cids_ai; Type: TRIGGER; Schema: eth; Owner: -
 --
 
-CREATE TRIGGER transaction_cids_ai AFTER INSERT ON eth.transaction_cids FOR EACH ROW EXECUTE PROCEDURE eth.graphql_subscription('transaction_cids', 'id');
+CREATE TRIGGER transaction_cids_ai AFTER INSERT ON eth.transaction_cids FOR EACH ROW EXECUTE FUNCTION eth.graphql_subscription('transaction_cids', 'id');
 
 
 --
 -- Name: uncle_cids uncle_cids_ai; Type: TRIGGER; Schema: eth; Owner: -
 --
 
-CREATE TRIGGER uncle_cids_ai AFTER INSERT ON eth.uncle_cids FOR EACH ROW EXECUTE PROCEDURE eth.graphql_subscription('uncle_cids', 'id');
+CREATE TRIGGER uncle_cids_ai AFTER INSERT ON eth.uncle_cids FOR EACH ROW EXECUTE FUNCTION eth.graphql_subscription('uncle_cids', 'id');
 
 
 --


### PR DESCRIPTION
Closes https://github.com/vulcanize/statediff-migrations/issues/12
Closes https://github.com/vulcanize/statediff-migrations/issues/13

Also, the renaming of the rct_mh_index and rct_cid_index were mixed up in the UP (rct_mh_index => rct_leaf_cid_index, rct_cid_index=> rct_leaf_mh_key_index)

Also, add a Makefile target for running "DOWN" migrations